### PR TITLE
fix, ELB instances getting reset for ASG use

### DIFF
--- a/infra.tf
+++ b/infra.tf
@@ -239,7 +239,7 @@ resource "aws_elb" "rancher" {
     interval            = 5
   }
 
-  instances    = aws_instance.rancher_worker.*.id
+  instances    = local.use_asgs_for_rancher_infra ? null : aws_instance.rancher_worker.*.id
   idle_timeout = 1800
 
   tags = {


### PR DESCRIPTION
Without this fix when using an ASG the ELB will be forced to clear its registered instances which is painful and not good (although possible to remediate by hand).