### PR TITLE
Allow current password rancher

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,9 @@ module "rancher_server" {
 | rancher2\_master\_subnet\_ids | List of subnet ids for Rancher master nodes | list | `[]` | no |
 | rancher2\_worker\_subnet\_ids | List of subnet ids for Rancher worker nodes | list | `[]` | no |
 | rancher\_chart | Helm chart to use for Rancher install | string | `"rancher-stable/rancher"` | no |
+| rancher\_current\_password | Rancher admin user current password | string | `"null"` | no |
 | rancher\_nodes\_in\_asgs | Control whether to put Rancher nodes in ASGs | bool | `"true"` | no |
-| rancher\_password |  | string | n/a | yes |
+| rancher\_password | Password to set for Rancher root user | string | n/a | yes |
 | rancher\_version | Version of Rancher to install | string | `"2.2.9"` | no |
 | rke\_backups\_region | Region to perform backups to S3 in. Defaults to aws_region | string | `""` | no |
 | rke\_backups\_s3\_endpoint | Override for S3 endpoint to use for backups | string | `""` | no |

--- a/rancher-ha.tf
+++ b/rancher-ha.tf
@@ -94,7 +94,8 @@ resource "rancher2_bootstrap" "admin" {
 
   depends_on = [null_resource.wait_for_rancher]
 
-  password = var.rancher_password
+  current_password = var.rancher_current_password
+  password         = var.rancher_password
 }
 
 resource "rancher2_auth_config_github" "github" {

--- a/variables.tf
+++ b/variables.tf
@@ -3,6 +3,12 @@ variable "rancher_password" {
   description = "Password to set for Rancher root user"
 }
 
+variable "rancher_current_password" {
+  type        = string
+  default     = null
+  description = "Rancher admin user current password"
+}
+
 variable "rancher_version" {
   type        = string
   default     = "2.2.9"

--- a/variables.tf
+++ b/variables.tf
@@ -1,5 +1,6 @@
 variable "rancher_password" {
-  type = string
+  type        = string
+  description = "Password to set for Rancher root user"
 }
 
 variable "rancher_version" {


### PR DESCRIPTION
This allows the current Rancher admin password to be passed in and used by the rancher-server module.

This is needed to allow re-runs in certain situations. I'm pinging Raul to see if maybe the `rancher2_bootstrap` resource couldn't be modified to make this unnecessary