### PR TITLE
Save api endpoint in r53

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ module "rancher_server" {
 | etcd\_backup\_user\_secret | AWS IAM secret access key for etcd backup user |
 | master\_addresses | IP addresses of Rancher master nodes |
 | rancher\_admin\_password | Password set for Rancher local admin user |
+| rancher\_api\_url | FQDN of Rancher's Kubernetes API endpoint |
 | rancher\_token | Admin token for Rancher cluster use |
 | rancher\_url | URL at which to reach Rancher |
 | worker\_addresses | IP addresses of Rancher worker nodes |

--- a/files/kube_config_cluster.yml
+++ b/files/kube_config_cluster.yml
@@ -4,8 +4,9 @@ kind: Config
 clusters:
   - cluster:
       api-version: v1
-      certificate-authority-data: ${rancher_cluster_ca}
+      # certificate-authority-data: ${rancher_cluster_ca}
       server: "${api_server_url}"
+      insecure-skip-tls-verify: true
     name: "rancher-management"
 contexts:
   - context:

--- a/files/kube_config_cluster.yml
+++ b/files/kube_config_cluster.yml
@@ -1,0 +1,20 @@
+---
+apiVersion: v1
+kind: Config
+clusters:
+  - cluster:
+      api-version: v1
+      certificate-authority-data: ${rancher_cluster_ca}
+      server: "${api_server_url}"
+    name: "rancher-management"
+contexts:
+  - context:
+      cluster: "rancher-management"
+      user: "kube-admin-rancher-management"
+    name: "rancher-management"
+current-context: "rancher-management"
+users:
+  - name: "kube-admin-rancher-management"
+    user:
+      client-certificate-data: ${rancher_user_cert}
+      client-key-data: ${rancher_user_key}

--- a/files/kube_config_cluster.yml
+++ b/files/kube_config_cluster.yml
@@ -4,9 +4,9 @@ kind: Config
 clusters:
   - cluster:
       api-version: v1
-      # certificate-authority-data: ${rancher_cluster_ca}
+      certificate-authority-data: ${rancher_cluster_ca}
       server: "${api_server_url}"
-      insecure-skip-tls-verify: true
+      # insecure-skip-tls-verify: true
     name: "rancher-management"
 contexts:
   - context:

--- a/infra.tf
+++ b/infra.tf
@@ -282,6 +282,14 @@ resource "aws_route53_record" "rancher" {
   }
 }
 
+resource "aws_route53_record" "rancher_api" {
+  zone_id  = data.aws_route53_zone.dns_zone.zone_id
+  name     = "api.${local.name}.${local.domain}"
+  type     = "A"
+  provider = aws.r53
+  records  = data.aws_instances.rancher_master.public_ips
+}
+
 ########################################
 ### Wait for docker install on nodes
 ########################################

--- a/infra.tf
+++ b/infra.tf
@@ -285,6 +285,7 @@ resource "aws_route53_record" "rancher" {
 resource "aws_route53_record" "rancher_api" {
   zone_id  = data.aws_route53_zone.dns_zone.zone_id
   name     = "api.${local.name}.${local.domain}"
+  ttl      = 60
   type     = "A"
   provider = aws.r53
   records  = data.aws_instances.rancher_master.public_ips

--- a/locals.tf
+++ b/locals.tf
@@ -1,9 +1,12 @@
 locals {
-  name              = var.name
-  rancher_version   = var.rancher_version
-  le_email          = var.le_email
-  domain            = var.domain
-  r53_domain        = length(var.r53_domain) > 0 ? var.r53_domain : local.domain
+  name            = var.name
+  rancher_version = var.rancher_version
+  le_email        = var.le_email
+  domain          = var.domain
+  r53_domain      = length(var.r53_domain) > 0 ? var.r53_domain : local.domain
+
+  api_server_url = "https://${aws_route53_record.rancher_api.fqdn}:6443"
+
   instance_type     = var.instance_type
   master_node_count = var.master_node_count
   worker_node_count = var.worker_node_count

--- a/locals.tf
+++ b/locals.tf
@@ -5,7 +5,8 @@ locals {
   domain          = var.domain
   r53_domain      = length(var.r53_domain) > 0 ? var.r53_domain : local.domain
 
-  api_server_url = "https://${aws_route53_record.rancher_api.fqdn}:6443"
+  api_server_url      = "https://${aws_route53_record.rancher_api.fqdn}:6443"
+  api_server_hostname = aws_route53_record.rancher_api.fqdn
 
   instance_type     = var.instance_type
   master_node_count = var.master_node_count

--- a/output.tf
+++ b/output.tf
@@ -20,7 +20,7 @@ output "rancher_url" {
 }
 
 output "rancher_api_url" {
-  value       = "https://${aws_route53_record.rancher_api.fqdn}:6443"
+  value       = local.api_server_url
   description = "FQDN of Rancher's Kubernetes API endpoint"
 }
 

--- a/output.tf
+++ b/output.tf
@@ -19,6 +19,11 @@ output "rancher_url" {
   description = "URL at which to reach Rancher"
 }
 
+output "rancher_api_url" {
+  value       = "https://${aws_route53_record.rancher_api.fqdn}:6443"
+  description = "FQDN of Rancher's Kubernetes API endpoint"
+}
+
 output "rancher_token" {
   value       = rancher2_bootstrap.admin.token
   sensitive   = true

--- a/provider.tf
+++ b/provider.tf
@@ -18,11 +18,11 @@ provider "helm" {
   insecure = true
 
   kubernetes {
-    host                   = local.api_server_url
-    client_certificate     = rke_cluster.rancher_server.client_cert
-    client_key             = rke_cluster.rancher_server.client_key
-    cluster_ca_certificate = rke_cluster.rancher_server.ca_crt
-    insecure               = true
+    host               = local.api_server_url
+    client_certificate = rke_cluster.rancher_server.client_cert
+    client_key         = rke_cluster.rancher_server.client_key
+    # cluster_ca_certificate = rke_cluster.rancher_server.ca_crt
+    insecure = true
   }
 }
 

--- a/provider.tf
+++ b/provider.tf
@@ -18,7 +18,11 @@ provider "helm" {
   insecure = true
 
   kubernetes {
-    config_path = local_file.kube_cluster_yaml.filename
+    host                   = local.api_server_url
+    client_certificate     = rke_cluster.rancher_server.client_cert
+    client_key             = rke_cluster.rancher_server.client_key
+    cluster_ca_certificate = rke_cluster.rancher_server.ca_crt
+    insecure               = true
   }
 }
 

--- a/provider.tf
+++ b/provider.tf
@@ -15,6 +15,8 @@ provider "helm" {
   namespace       = "kube-system"
   service_account = "tiller"
 
+  insecure = true
+
   kubernetes {
     config_path = local_file.kube_cluster_yaml.filename
   }

--- a/provider.tf
+++ b/provider.tf
@@ -15,14 +15,8 @@ provider "helm" {
   namespace       = "kube-system"
   service_account = "tiller"
 
-  # insecure = true
-
   kubernetes {
-    host               = local.api_server_url
-    client_certificate = rke_cluster.rancher_server.client_cert
-    client_key         = rke_cluster.rancher_server.client_key
-    # cluster_ca_certificate = rke_cluster.rancher_server.ca_crt
-    insecure = true
+    config_path = local_file.kube_cluster_yaml.filename
   }
 }
 

--- a/provider.tf
+++ b/provider.tf
@@ -15,7 +15,7 @@ provider "helm" {
   namespace       = "kube-system"
   service_account = "tiller"
 
-  insecure = true
+  # insecure = true
 
   kubernetes {
     host               = local.api_server_url

--- a/rke.tf
+++ b/rke.tf
@@ -49,5 +49,10 @@ resource "rke_cluster" "rancher_server" {
 
 resource "local_file" "kube_cluster_yaml" {
   filename = "${path.root}/outputs/kube_config_cluster.yml"
-  content  = rke_cluster.rancher_server.kube_config_yaml
+  content = templatefile("${path.module}/files/kube_config_cluster.yml", {
+    api_server_url     = local.api_server_url
+    rancher_cluster_ca = rke_cluster.rancher_server.ca_crt
+    rancher_user_cert  = rke_cluster.rancher_server.client_cert
+    rancher_user_key   = rke_cluster.rancher_server.client_key
+  })
 }

--- a/rke.tf
+++ b/rke.tf
@@ -29,6 +29,14 @@ resource "rke_cluster" "rancher_server" {
   cluster_name = "rancher-management"
   addons       = file("${path.module}/files/addons.yaml")
 
+  authentication {
+    strategy = "x509"
+
+    sans = [
+      local.api_server_hostname
+    ]
+  }
+
   services_etcd {
     # for etcd snapshots
     backup_config {

--- a/rke.tf
+++ b/rke.tf
@@ -51,8 +51,8 @@ resource "local_file" "kube_cluster_yaml" {
   filename = "${path.root}/outputs/kube_config_cluster.yml"
   content = templatefile("${path.module}/files/kube_config_cluster.yml", {
     api_server_url     = local.api_server_url
-    rancher_cluster_ca = rke_cluster.rancher_server.ca_crt
-    rancher_user_cert  = rke_cluster.rancher_server.client_cert
-    rancher_user_key   = rke_cluster.rancher_server.client_key
+    rancher_cluster_ca = base64encode(rke_cluster.rancher_server.ca_crt)
+    rancher_user_cert  = base64encode(rke_cluster.rancher_server.client_cert)
+    rancher_user_key   = base64encode(rke_cluster.rancher_server.client_key)
   })
 }


### PR DESCRIPTION
Based on branch at https://github.com/rancher/terraform-rancher-server/pull/5

Saves current IPs of master nodes into R53 record for API access, and creates kubeconfig for use of such from a template

Notably the kubeconfig must use insecure mode to access the api server, this is a known issue with rke (https://github.com/rancher/rke/issues/1682 )

A possible workaround might be to change the apiserver certificate in use out-of-band of rke via terraform.