### PR TITLE
fix helm provider backward compatibility. 

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,4 +1,7 @@
 
 terraform {
   required_version = ">= 0.12"
+  required_providers {
+    helm = "0.10.4"
+  }
 }


### PR DESCRIPTION
Use helm provider version "0.10.4". This is the last version with helm 2 support.